### PR TITLE
Fix: Links broken to Robocorp documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Machine Learning API examples
 
-These examples demonstrate how to use cloud-based ML APIs with [RPA Framework](/libraries/rpa-framework/). Currently, a selected set of services from [AWS](https://aws.amazon.com/) ([RPA.Cloud.AWS](/libraries/rpa-framework/rpa-cloud-aws/)), [Microsoft Azure](https://azure.microsoft.com/) ([RPA.Cloud.Azure](/libraries/rpa-framework/rpa-cloud-azure/)) and [Google Cloud](https://cloud.google.com/) ([RPA.Cloud.Google](/libraries/rpa-framework/rpa-cloud-google/)) are available.
+These examples demonstrate how to use cloud-based ML APIs with [RPA Framework](https://robocorp.com/docs/libraries/rpa-framework). Currently, a selected set of services from [AWS](https://aws.amazon.com/) ([RPA.Cloud.AWS](https://robocorp.com/docs/libraries/rpa-framework/rpa-cloud-aws/)), [Microsoft Azure](https://azure.microsoft.com/) ([RPA.Cloud.Azure](https://robocorp.com/docs/libraries/rpa-framework/rpa-cloud-azure/)) and [Google Cloud](https://cloud.google.com/) ([RPA.Cloud.Google](https://robocorp.com/docs/libraries/rpa-framework/rpa-cloud-google/)) are available.
 
 > NOTE: This example needs some manual configuration steps. You can find the full tutorial and instructions on [Robocorp's documentation site](https://robocorp.com/docs/development-guide/ai-machine-learning/cloud-machine-learning-apis).


### PR DESCRIPTION
Fix links directing to Robocorp documentation